### PR TITLE
Tell bumpversion to not update the history.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,6 @@ matrix:
 install:
   - virtualenv -p `which python` .
   - bin/pip install -r requirements.txt
-  - bin/python setup.py install
+  - bin/python setup.py develop
 script:
   - bin/python setup.py test

--- a/news/10.bugfix
+++ b/news/10.bugfix
@@ -1,0 +1,2 @@
+Tell bumpversion to not update the history.
+[maurits]

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,11 @@ setup(
         'zest.releaser>=6.15.0',
     ],
     entry_points={
+        'zest.releaser.bumpversion.before': [
+            # If towncrier is configured for this project,
+            # the history should not be changed.
+            'check_towncrier = zestreleaser.towncrier:check_towncrier',
+        ],
         'zest.releaser.prereleaser.middle': [
             # Call towncrier to update the changelog with newsfragments:
             'call_towncrier = zestreleaser.towncrier:call_towncrier',

--- a/src/zestreleaser/towncrier/__init__.py
+++ b/src/zestreleaser/towncrier/__init__.py
@@ -53,7 +53,7 @@ def check_towncrier(data):
     if TOWNCRIER_MARKER in data:
         # We have already been called.
         return data[TOWNCRIER_MARKER]
-    if not data['update_history']:
+    if not data.get('update_history', True):
         # Someone has instructed zest.releaser to not update the history,
         # and it was not us, because our marker was not set,
         # so we should not update the history either.


### PR DESCRIPTION
Fixes issue #10.
Needs a fix in zest.releaser, although it does not break without it.