### PR TITLE
Do not run sanity checks or run draft during postrelease.

### DIFF
--- a/news/16.bugfix
+++ b/news/16.bugfix
@@ -1,0 +1,1 @@
+Do not run sanity checks or run draft during postrelease.  [maurits]

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ setup(
             # We only need to check if towncrier is available and
             # configured for this project.
             # Then the history should not be changed.
-            'check_towncrier = zestreleaser.towncrier:check_towncrier',
+            'check_towncrier = zestreleaser.towncrier:post_check_towncrier',
         ],
     },
 )


### PR DESCRIPTION
Fixes issue #16.
We could do less checks in `bumpversion` too, but it actually seems okay there.