### PR TITLE
Use 'python -m towncrier' when the script is not easily findable.

### DIFF
--- a/news/17.feature
+++ b/news/17.feature
@@ -1,0 +1,4 @@
+Use 'python -m towncrier' when the script is not easily findable.
+Still check the directory of the fullrelease script first.
+No longer check the PATH.
+[maurits]

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
     install_requires=[
         'setuptools',
         'toml',
-        'towncrier>=18.5.0',
+        'towncrier>=18.6.0',
         'zest.releaser>=6.17.0',
     ],
     entry_points={


### PR DESCRIPTION
Require towncrier 18.6.0 for this.
Still check the directory of the fullrelease script first.
No longer check the PATH.
Fixes issue #17.