### PR TITLE
Add build subcommand to towncrier when building the changelog

### DIFF
--- a/src/zestreleaser/towncrier/__init__.py
+++ b/src/zestreleaser/towncrier/__init__.py
@@ -171,6 +171,7 @@ def check_towncrier(data, check_sanity=True, do_draft=True):
                 # Do a draft.
                 cmd = deepcopy(result)
                 cmd.extend([
+                    'build',
                     '--draft',
                     '--version', data.get('new_version', 't.b.d.'),
                     '--yes',
@@ -208,7 +209,7 @@ def call_towncrier(data):
         return
     # path is a list
     cmd = deepcopy(path)
-    cmd.extend(['--version', data['new_version'], '--yes'])
+    cmd.extend(['build', '--version', data['new_version'], '--yes'])
     # We would like to pass ['--package' 'package name'] as well,
     # but that is not yet in a release of towncrier.
     logger.info(


### PR DESCRIPTION
This pull request is meant to address #21 by adding the explicit *build* subcommand when running *towncrier* to create the new changelog.

That is, `towncrier build --draft --version t.b.d` instead of `towncrier --draft --version t.b.d`.

It appears that *towncrier* has accepted the *build* subcommand for quite some time so there shouldn't be any backward compatibility issues.