### PR TITLE
Grab changelog

### DIFF
--- a/news/25.feature
+++ b/news/25.feature
@@ -1,0 +1,3 @@
+Save the changes internally so that `zest.releaser`
+can use it later on during the release process.
+[gforcada]

--- a/src/zestreleaser/towncrier/__init__.py
+++ b/src/zestreleaser/towncrier/__init__.py
@@ -206,7 +206,15 @@ def check_towncrier(data, check_sanity=True, do_draft=True):
                     "Doing dry-run of towncrier to see what would be changed: %s",
                     utils.format_command(cmd),
                 )
-                print(utils.execute_command(cmd))
+                output = utils.execute_command(cmd)
+                print(output)
+                # remove the first two lines that are the release and the underline,
+                # at least on rst files, and remove the output generated
+                # by towncrier itself
+                cleaned_output = [
+                    x for x in output.split('\n')[2:] if not x.startswith('\x1b')
+                ]
+                data["history_this_release"] = '\n'.join(cleaned_output)
         else:
             print(
                 dedent(


### PR DESCRIPTION
Fixes #25 

Part of https://github.com/zestsoftware/zest.releaser/issues/218

See https://github.com/zestsoftware/zest.releaser/pull/439 for the changes needed in `zest.releaser` that use this.

The clean up logic is a bit centric to `.rst` files, but it could be (easily?) adapted to `.md` files as well.

Or maybe it is not even needed, to cut the release heading? Specially considering that one can use `jinja` to format the change long differently.