### PR TITLE
Update our towncrier integration

### DIFF
--- a/news/27.bugfix.rst
+++ b/news/27.bugfix.rst
@@ -1,0 +1,3 @@
+Also look for ``towncrier.toml``, next to ``pyproject.toml``.
+``towncrier.toml`` is tried first.
+[maurits]

--- a/news/29.feature.rst
+++ b/news/29.feature.rst
@@ -1,0 +1,1 @@
+Call ``towncrier check`` instead of doing those checks ourselves.  [maurits]

--- a/src/zestreleaser/towncrier/__init__.py
+++ b/src/zestreleaser/towncrier/__init__.py
@@ -15,7 +15,10 @@ else:
 
 logger = logging.getLogger(__name__)
 TOWNCRIER_MARKER = "_towncrier_applicable"
-TOWNCRIER_CONFIG_FILE = "pyproject.toml"
+TOWNCRIER_CONFIG_FILES = [
+    "towncrier.toml",
+    "pyproject.toml",
+]
 
 
 def _towncrier_executable():
@@ -51,12 +54,20 @@ def _towncrier_executable():
 
 
 def _load_config():
-    with open(TOWNCRIER_CONFIG_FILE, "rb") as conffile:
-        return tomllib.load(conffile)
+    for filename in TOWNCRIER_CONFIG_FILES:
+        if not os.path.exists(filename):
+            continue
+        with open(filename, "rb") as conffile:
+            return tomllib.load(conffile)
 
 
 def _is_towncrier_wanted():
-    if not os.path.exists(TOWNCRIER_CONFIG_FILE):
+    found = False
+    for filename in TOWNCRIER_CONFIG_FILES:
+        if os.path.exists(filename):
+            found = True
+            break
+    if not found:
         return
     full_config = _load_config()
     try:

--- a/src/zestreleaser/towncrier/__init__.py
+++ b/src/zestreleaser/towncrier/__init__.py
@@ -133,8 +133,6 @@ def check_towncrier(data, check_sanity=True, do_draft=True):
                         "--yes",
                     ]
                 )
-                # We would like to pass ['--package' 'package name'] as well,
-                # but that is not yet in a release of towncrier.
                 logger.info(
                     "Doing dry-run of towncrier to see what would be changed: %s",
                     utils.format_command(cmd),

--- a/src/zestreleaser/towncrier/__init__.py
+++ b/src/zestreleaser/towncrier/__init__.py
@@ -130,7 +130,6 @@ def check_towncrier(data, check_sanity=True, do_draft=True):
                         "--draft",
                         "--version",
                         data.get("new_version", "t.b.d."),
-                        "--yes",
                     ]
                 )
                 logger.info(


### PR DESCRIPTION
@icemac Can you try this out please?  It finally solves two issues you created a few months ago:

* First look for `towncrier.toml` file, then `pyproject.toml`.  Fixes issue #27.
* Call `towncrier check` instead of having our own checks.  Fixes issue #29.

Note that today I have also switched to native namespace, and require Python 3.10+.  See my merged PR #30.